### PR TITLE
CurveSNARK1 for Go

### DIFF
--- a/mcl/include/mcl/bn.h
+++ b/mcl/include/mcl/bn.h
@@ -74,7 +74,8 @@ enum {
 	mclBn_CurveFp254BNb = 0,
 	mclBn_CurveFp382_1 = 1,
 	mclBn_CurveFp382_2 = 2,
-	mclBn_CurveFp462 = 3
+	mclBn_CurveFp462 = 3,
+	mclBn_CurveSNARK1 = 4
 };
 
 /*

--- a/mcl/src/bn_c_impl.hpp
+++ b/mcl/src/bn_c_impl.hpp
@@ -125,6 +125,9 @@ int mclBn_init(int curve, int maxUnitSize)
 		cp = mcl::bn::CurveFp462;
 		break;
 #endif
+  case mclBn_CurveSNARK1:
+	  cp = mcl::bn::CurveSNARK1;
+	break;
 	default:
 		if (g_fp) fprintf(g_fp, "MCLBN_init:not supported curve %d\n", curve);
 		return -1;

--- a/mcl/src/bn_c_impl.hpp
+++ b/mcl/src/bn_c_impl.hpp
@@ -125,8 +125,8 @@ int mclBn_init(int curve, int maxUnitSize)
 		cp = mcl::bn::CurveFp462;
 		break;
 #endif
-  case mclBn_CurveSNARK1:
-	  cp = mcl::bn::CurveSNARK1;
+	case mclBn_CurveSNARK1:
+		cp = mcl::bn::CurveSNARK1;
 	break;
 	default:
 		if (g_fp) fprintf(g_fp, "MCLBN_init:not supported curve %d\n", curve);


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/31

This PR is the first step towards exposing `CurveSNARK1` to our Go code.

Two other actions needed that will be implemented in separate PRs: 
1. Exposing `CurveSNARK1` in [our fork](https://github.com/keep-network/go-dfinity-crypto) of `go-dfinity-crypto`
2. Switching from `github.com/keep-network/go-dfinity-crypto/bls` to `github.com/keep-network/go-dfinity-crypto/bls` in the `keep-core`

I did not manage to run tests for `mcl`. Makefile `test` target refers to some non-existing source code and is implemented for Windows. Although I can fix the latter, I don't know what to do with former. However, I'll add `CurveSNARK1` case to the unit tests in `go-dfinity-crypto` so we should be safe.